### PR TITLE
sandbox: do not specify GDB hostname

### DIFF
--- a/src/sandbox-posix.c
+++ b/src/sandbox-posix.c
@@ -834,7 +834,7 @@ int bxfi_exec(bxf_instance **out, bxf_sandbox *sandbox,
 
         switch (sandbox->debug.debugger) {
             case BXF_DBG_GDB:
-                snprintf(port, sizeof (port), "tcp:%d", sandbox->debug.tcp);
+                snprintf(port, sizeof (port), ":%d", sandbox->debug.tcp);
                 break;
             case BXF_DBG_LLDB:
                 argv[argc++] = "gdbserver";

--- a/src/sandbox-windows.c
+++ b/src/sandbox-windows.c
@@ -423,7 +423,7 @@ int bxfi_exec(bxf_instance **out, bxf_sandbox *sandbox,
             } break;
             case BXF_DBG_GDB: {
                 dbg = TEXT("gdbserver");
-                TCHAR *fmt = TEXT("boxfort-worker tcp:%d %s %s");
+                TCHAR *fmt = TEXT("boxfort-worker :%d %s %s");
 
                 size = _sctprintf(fmt, sandbox->debug.tcp, filename,
                         env_map);


### PR DESCRIPTION
gdbserver requires the first parameter to be `HOST:PORT`.
In gdbserver 8.3, the hostname is actually resolved with `getaddrinfo()`, so the string "tcp" can not be used anymore.

Omitting HOST defaults to "localhost".

Fixes Criterion's `--debug` flag:
```
[----] Criterion v2.3.2
[====] Running 4 tests from date:
tcp:4214: cannot resolve name: No address associated with hostname
Exiting
criterion: Could not spawn test instance: Protocol error
fish: “modules/date/tests/test_date --…” terminated by signal SIGABRT (Abort)
```